### PR TITLE
fix: Fix useFunnel return values and parameter type

### DIFF
--- a/dist/hooks/useFunnel/useFunnel.d.ts
+++ b/dist/hooks/useFunnel/useFunnel.d.ts
@@ -4,11 +4,15 @@ import { ReactNode } from "react";
  *
  * @param {string[]} steps An array of the name of the steps.
  */
-export default function useFunnel<S extends string>(steps: [S, ...S[]]): readonly [(({ children }: {
-    children: ReactNode;
-}) => import("react/jsx-runtime").JSX.Element) & {
-    Step: ({ children }: {
-        name: S;
+export default function useFunnel<S extends string>(steps: S[]): {
+    readonly currentStep: S;
+    readonly FunnelComponent: (({ children }: {
         children: ReactNode;
-    }) => import("react/jsx-runtime").JSX.Element;
-}, (step: S) => void];
+    }) => import("react/jsx-runtime").JSX.Element) & {
+        Step: ({ children }: {
+            name: S;
+            children: ReactNode;
+        }) => import("react/jsx-runtime").JSX.Element;
+    };
+    readonly changeStep: (step: S) => void;
+};

--- a/dist/hooks/useFunnel/useFunnel.d.ts
+++ b/dist/hooks/useFunnel/useFunnel.d.ts
@@ -6,7 +6,7 @@ import { ReactNode } from "react";
  */
 export default function useFunnel<S extends string>(steps: S[]): {
     readonly currentStep: S;
-    readonly FunnelComponent: (({ children }: {
+    readonly Funnel: (({ children }: {
         children: ReactNode;
     }) => import("react/jsx-runtime").JSX.Element) & {
         Step: ({ children }: {

--- a/dist/hooks/useFunnel/useFunnel.js
+++ b/dist/hooks/useFunnel/useFunnel.js
@@ -19,7 +19,7 @@ function useFunnel(steps) {
     }
     // Funnel Component
     // Receives only Step components as children.
-    function Funnel({ children }) {
+    function FunnelComponent({ children }) {
         const targetStep = react_1.Children.toArray(children).find((child) => {
             if (!(0, react_1.isValidElement)(child) || child.type !== Step) {
                 throw new Error(`${(0, react_1.isValidElement)(child) ? child.type : child} is not a <Funnel.Step> component. All component children of <Funnel> must be a <Funnel.Step>.`);
@@ -28,10 +28,10 @@ function useFunnel(steps) {
         });
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: targetStep });
     }
-    const FunnelComponent = (0, react_1.useMemo)(() => Object.assign(Funnel, { Step }), 
+    const FunnelComponentMemo = (0, react_1.useMemo)(() => Object.assign(FunnelComponent, { Step }), 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentStep]);
-    return { currentStep, FunnelComponent, changeStep };
+    return { currentStep, Funnel: FunnelComponentMemo, changeStep };
 }
 exports.default = useFunnel;
 //# sourceMappingURL=useFunnel.js.map

--- a/dist/hooks/useFunnel/useFunnel.js
+++ b/dist/hooks/useFunnel/useFunnel.js
@@ -31,7 +31,7 @@ function useFunnel(steps) {
     const FunnelComponent = (0, react_1.useMemo)(() => Object.assign(Funnel, { Step }), 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentStep]);
-    return [FunnelComponent, changeStep];
+    return { currentStep, FunnelComponent, changeStep };
 }
 exports.default = useFunnel;
 //# sourceMappingURL=useFunnel.js.map

--- a/dist/hooks/useFunnel/useFunnel.test.js
+++ b/dist/hooks/useFunnel/useFunnel.test.js
@@ -8,7 +8,7 @@ const react_1 = require("@testing-library/react");
 const react_2 = __importDefault(require("react"));
 const useFunnel_1 = __importDefault(require("./useFunnel"));
 function TestComponent() {
-    const [Funnel, changeStep] = (0, useFunnel_1.default)(["step1", "step2"]);
+    const { FunnelComponent: Funnel, changeStep } = (0, useFunnel_1.default)(["step1", "step2"]);
     return ((0, jsx_runtime_1.jsxs)(react_2.default.Fragment, { children: [(0, jsx_runtime_1.jsxs)(Funnel, { children: [(0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step1", children: "Step 1 UI" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step2", children: "Step 2 UI" })] }), (0, jsx_runtime_1.jsx)("button", { onClick: () => changeStep("step2"), children: "Next Step" })] }));
 }
 describe("useFunnel hook", () => {
@@ -22,14 +22,14 @@ describe("useFunnel hook", () => {
     });
     it("should return a tuple containing a Funnel component (with a Step property) and changeStep function", () => {
         const { result } = (0, react_1.renderHook)(() => (0, useFunnel_1.default)(["step1"]));
-        const [Funnel, changeStep] = result.current;
+        const { FunnelComponent: Funnel, changeStep } = result.current;
         expect(Funnel).toBeDefined(); // Funnel
         expect(Funnel.Step).toBeDefined(); // Funnel.Step
         expect(changeStep).toBeDefined(); // changeStep
     });
     it("should only accept Funnel.Step as children in the Funnel component", () => {
         const { result } = (0, react_1.renderHook)(() => (0, useFunnel_1.default)(["step1", "step2"]));
-        const [Funnel] = result.current;
+        const { FunnelComponent: Funnel } = result.current;
         const renderWithInvalidChild = () => (0, react_1.render)((0, jsx_runtime_1.jsx)(react_2.default.Fragment, { children: (0, jsx_runtime_1.jsxs)(Funnel, { children: [(0, jsx_runtime_1.jsx)("div", { children: "I shouldn't be allowed" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step1", children: "Step 1 UI" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step2", children: "Step 2 UI" })] }) }));
         expect(renderWithInvalidChild).toThrow("div is not a <Funnel.Step> component. All component children of <Funnel> must be a <Funnel.Step>.");
     });

--- a/dist/hooks/useFunnel/useFunnel.test.js
+++ b/dist/hooks/useFunnel/useFunnel.test.js
@@ -8,7 +8,8 @@ const react_1 = require("@testing-library/react");
 const react_2 = __importDefault(require("react"));
 const useFunnel_1 = __importDefault(require("./useFunnel"));
 function TestComponent() {
-    const { FunnelComponent: Funnel, changeStep } = (0, useFunnel_1.default)(["step1", "step2"]);
+    const stepList = ["step1", "step2"];
+    const { FunnelComponent: Funnel, changeStep } = (0, useFunnel_1.default)(stepList);
     return ((0, jsx_runtime_1.jsxs)(react_2.default.Fragment, { children: [(0, jsx_runtime_1.jsxs)(Funnel, { children: [(0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step1", children: "Step 1 UI" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step2", children: "Step 2 UI" })] }), (0, jsx_runtime_1.jsx)("button", { onClick: () => changeStep("step2"), children: "Next Step" })] }));
 }
 describe("useFunnel hook", () => {

--- a/dist/hooks/useFunnel/useFunnel.test.js
+++ b/dist/hooks/useFunnel/useFunnel.test.js
@@ -9,7 +9,7 @@ const react_2 = __importDefault(require("react"));
 const useFunnel_1 = __importDefault(require("./useFunnel"));
 function TestComponent() {
     const stepList = ["step1", "step2"];
-    const { FunnelComponent: Funnel, changeStep } = (0, useFunnel_1.default)(stepList);
+    const { Funnel, changeStep } = (0, useFunnel_1.default)(stepList);
     return ((0, jsx_runtime_1.jsxs)(react_2.default.Fragment, { children: [(0, jsx_runtime_1.jsxs)(Funnel, { children: [(0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step1", children: "Step 1 UI" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step2", children: "Step 2 UI" })] }), (0, jsx_runtime_1.jsx)("button", { onClick: () => changeStep("step2"), children: "Next Step" })] }));
 }
 describe("useFunnel hook", () => {
@@ -23,14 +23,14 @@ describe("useFunnel hook", () => {
     });
     it("should return a tuple containing a Funnel component (with a Step property) and changeStep function", () => {
         const { result } = (0, react_1.renderHook)(() => (0, useFunnel_1.default)(["step1"]));
-        const { FunnelComponent: Funnel, changeStep } = result.current;
+        const { Funnel, changeStep } = result.current;
         expect(Funnel).toBeDefined(); // Funnel
         expect(Funnel.Step).toBeDefined(); // Funnel.Step
         expect(changeStep).toBeDefined(); // changeStep
     });
     it("should only accept Funnel.Step as children in the Funnel component", () => {
         const { result } = (0, react_1.renderHook)(() => (0, useFunnel_1.default)(["step1", "step2"]));
-        const { FunnelComponent: Funnel } = result.current;
+        const { Funnel } = result.current;
         const renderWithInvalidChild = () => (0, react_1.render)((0, jsx_runtime_1.jsx)(react_2.default.Fragment, { children: (0, jsx_runtime_1.jsxs)(Funnel, { children: [(0, jsx_runtime_1.jsx)("div", { children: "I shouldn't be allowed" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step1", children: "Step 1 UI" }), (0, jsx_runtime_1.jsx)(Funnel.Step, { name: "step2", children: "Step 2 UI" })] }) }));
         expect(renderWithInvalidChild).toThrow("div is not a <Funnel.Step> component. All component children of <Funnel> must be a <Funnel.Step>.");
     });

--- a/packages/hooks/useFunnel/useFunnel.test.tsx
+++ b/packages/hooks/useFunnel/useFunnel.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import useFunnel from "./useFunnel";
 
 function TestComponent() {
-  const [Funnel, changeStep] = useFunnel(["step1", "step2"]);
+  const { FunnelComponent: Funnel, changeStep } = useFunnel(["step1", "step2"]);
 
   return (
     <React.Fragment>
@@ -30,7 +30,7 @@ describe("useFunnel hook", () => {
 
   it("should return a tuple containing a Funnel component (with a Step property) and changeStep function", () => {
     const { result } = renderHook(() => useFunnel(["step1"]));
-    const [Funnel, changeStep] = result.current;
+    const { FunnelComponent: Funnel, changeStep } = result.current;
 
     expect(Funnel).toBeDefined(); // Funnel
     expect(Funnel.Step).toBeDefined(); // Funnel.Step
@@ -39,7 +39,7 @@ describe("useFunnel hook", () => {
 
   it("should only accept Funnel.Step as children in the Funnel component", () => {
     const { result } = renderHook(() => useFunnel(["step1", "step2"]));
-    const [Funnel] = result.current;
+    const { FunnelComponent: Funnel } = result.current;
 
     const renderWithInvalidChild = () =>
       render(

--- a/packages/hooks/useFunnel/useFunnel.test.tsx
+++ b/packages/hooks/useFunnel/useFunnel.test.tsx
@@ -4,7 +4,7 @@ import useFunnel from "./useFunnel";
 
 function TestComponent() {
   const stepList = ["step1", "step2"];
-  const { FunnelComponent: Funnel, changeStep } = useFunnel(stepList);
+  const { Funnel, changeStep } = useFunnel(stepList);
 
   return (
     <React.Fragment>
@@ -31,7 +31,7 @@ describe("useFunnel hook", () => {
 
   it("should return a tuple containing a Funnel component (with a Step property) and changeStep function", () => {
     const { result } = renderHook(() => useFunnel(["step1"]));
-    const { FunnelComponent: Funnel, changeStep } = result.current;
+    const { Funnel, changeStep } = result.current;
 
     expect(Funnel).toBeDefined(); // Funnel
     expect(Funnel.Step).toBeDefined(); // Funnel.Step
@@ -40,7 +40,7 @@ describe("useFunnel hook", () => {
 
   it("should only accept Funnel.Step as children in the Funnel component", () => {
     const { result } = renderHook(() => useFunnel(["step1", "step2"]));
-    const { FunnelComponent: Funnel } = result.current;
+    const { Funnel } = result.current;
 
     const renderWithInvalidChild = () =>
       render(

--- a/packages/hooks/useFunnel/useFunnel.test.tsx
+++ b/packages/hooks/useFunnel/useFunnel.test.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import useFunnel from "./useFunnel";
 
 function TestComponent() {
-  const { FunnelComponent: Funnel, changeStep } = useFunnel(["step1", "step2"]);
+  const stepList = ["step1", "step2"];
+  const { FunnelComponent: Funnel, changeStep } = useFunnel(stepList);
 
   return (
     <React.Fragment>

--- a/packages/hooks/useFunnel/useFunnel.tsx
+++ b/packages/hooks/useFunnel/useFunnel.tsx
@@ -20,7 +20,7 @@ export default function useFunnel<S extends string>(steps: S[]) {
 
   // Funnel Component
   // Receives only Step components as children.
-  function Funnel({ children }: { children: ReactNode }) {
+  function FunnelComponent({ children }: { children: ReactNode }) {
     const targetStep = Children.toArray(children).find((child) => {
       if (!isValidElement(child) || child.type !== Step) {
         throw new Error(
@@ -35,11 +35,11 @@ export default function useFunnel<S extends string>(steps: S[]) {
     return <>{targetStep}</>;
   }
 
-  const FunnelComponent = useMemo(
-    () => Object.assign(Funnel, { Step }),
+  const FunnelComponentMemo = useMemo(
+    () => Object.assign(FunnelComponent, { Step }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentStep]
   );
 
-  return { currentStep, FunnelComponent, changeStep } as const;
+  return { currentStep, Funnel: FunnelComponentMemo, changeStep } as const;
 }

--- a/packages/hooks/useFunnel/useFunnel.tsx
+++ b/packages/hooks/useFunnel/useFunnel.tsx
@@ -5,7 +5,7 @@ import { Children, ReactNode, isValidElement, useMemo, useState } from "react";
  *
  * @param {string[]} steps An array of the name of the steps.
  */
-export default function useFunnel<S extends string>(steps: [S, ...S[]]) {
+export default function useFunnel<S extends string>(steps: S[]) {
   const [currentStep, setCurrentStep] = useState<S>(steps[0]);
 
   const changeStep = (step: S) => {
@@ -41,5 +41,5 @@ export default function useFunnel<S extends string>(steps: [S, ...S[]]) {
     [currentStep]
   );
 
-  return [FunnelComponent, changeStep] as const;
+  return { currentStep, FunnelComponent, changeStep } as const;
 }


### PR DESCRIPTION
## Overview
closes #1 

## Changes
1. The currentStep has been added to the return values of useFunnel
2. Changed the return type of useFunnel from an array to an object
3. The parameter type of useFunnel has been changed to String[]
4. In the test code of useFunnel, parameters are now passed as an array